### PR TITLE
Revert "Allocate tty so commands can be interrupted"

### DIFF
--- a/build_data.sh
+++ b/build_data.sh
@@ -28,7 +28,7 @@ fi
 mkdir -p packages
 chmod a+w packages
 
-docker run ${KEEP} -i -t --volume $(pwd)/packages:/home/nistmni/build $VM  /bin/bash <<END
+docker run ${KEEP} -i --volume $(pwd)/packages:/home/nistmni/build $VM  /bin/bash <<END
 
 mkdir src
 cd src

--- a/build_v1.sh
+++ b/build_v1.sh
@@ -20,7 +20,7 @@ echo "PARALLEL=$PARALLEL"
 mkdir -p packages
 chmod a+w packages
 
-docker run --rm -i -t --volume $(pwd)/packages:/home/nistmni/build $VM  /bin/bash <<END
+docker run --rm -i --volume $(pwd)/packages:/home/nistmni/build $VM  /bin/bash <<END
 mkdir src
 cd src
 git clone --recursive --branch develop https://github.com/BIC-MNI/minc-toolkit.git minc-toolkit

--- a/build_v2.sh
+++ b/build_v2.sh
@@ -28,7 +28,7 @@ fi
 mkdir -p packages
 chmod a+w packages
 
-docker run ${KEEP} -i -t --volume $(pwd)/packages:/home/nistmni/build $VM  /bin/bash <<END
+docker run ${KEEP} -i --volume $(pwd)/packages:/home/nistmni/build $VM  /bin/bash <<END
 mkdir src
 cd src
 git clone --recursive --branch develop https://github.com/BIC-MNI/minc-toolkit-v2.git minc-toolkit-v2


### PR DESCRIPTION
Reverts BIC-MNI/build_packages#1

This breaks the piped-in script you're using to build.

Need to find an alternate way to allow the docker to be interruptible.

Sorry.