### PR TITLE
add: centos 6.9 base docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,18 +9,19 @@ build [minc-toolkit](https://github.com/BIC-MNI/minc-toolkit) and [minc-toolkit-
 Setup docker using instructions from https://docs.docker.com/get-started/ ,
 make sure that user that will be using these scripts is a member of `docker`
 group, or use `sudo` to execute build scripts.
-After docker is successfully installed, execute `prepare_docker_build_images.sh` script - 
+After docker is successfully installed, execute `prepare_docker_build_images.sh` script -
 it will prepare docker images needed for building all versions of minc-toolkit.
 **WARNING** it will download quite a lot of stuff from docker.
 Currently following systems are supported:
 
+* Centos 6.9 , 64bit
 * Centos 7.3 , 64bit
 * Fedora 25  , 64bit
 * Debian 8   , 64bit
 * Ubuntu 14.04, 32&64bit
 * Ubuntu 16.04, 32&64bit
 
-If you need to build only for specific system, you can manually initialize docker image needed by running `docker build -t minc-<SYSTEM> <SYSTEM>`. 
+If you need to build only for specific system, you can manually initialize docker image needed by running `docker build -t minc-<SYSTEM> <SYSTEM>`.
 For example for ubuntu-16.04 64bit: `docker build -t minc-build_ubuntu_16.04_x64 build_ubuntu_16.04_x64`
 
 ## Building individual packages

--- a/build_centos_6.9_x64/Dockerfile
+++ b/build_centos_6.9_x64/Dockerfile
@@ -1,0 +1,45 @@
+FROM centos:6.9
+
+# install basic system packages
+RUN \
+    yum -y update && \
+    yum -y install deltarpm redhat-lsb-core wget bc which && \
+    yum -y groupinstall 'Development Tools'  && \
+    yum -y install sudo libX11-devel libXmu-devel libXi-devel \
+                   mesa-libGL-devel mesa-libGLU-devel \
+                   libjpeg-turbo-devel openjpeg-devel \
+                   openssl-devel rpm-build-libs rpm-devel && \
+    yum -y clean all && \
+    rm -rf /var/cache/yum/* /tmp/* /var/tmp/*
+
+# Install newer gcc, binutils, gfortran, libjpegturbo
+RUN wget http://people.centos.org/tru/devtools-2/devtools-2.repo -O /etc/yum.repos.d/devtools-2.repo && \
+    yum install -y -q devtoolset-2-gcc-c++ devtoolset-2-binutils devtoolset-2-gcc-gfortran && \
+    yum -y clean all && \
+    rm -rf /var/cache/yum/* /tmp/* /var/tmp/* && \
+    rpm -i https://sourceforge.net/projects/libjpeg-turbo/files/1.3.1/libjpeg-turbo-official-1.3.1.x86_64.rpm/download && \
+    echo "/opt/libjpeg-turbo/lib64" >> /etc/ld.so.conf && \
+    rm /etc/ld.so.cache && \
+    ldconfig
+ENV PATH=/opt/rh/devtoolset-2/root/usr/bin:$PATH
+
+# add user to build all tools
+RUN useradd -ms /bin/bash nistmni && \
+    echo "nistmni ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/nistmni && \
+    chmod 0440 /etc/sudoers.d/nistmni
+
+# add new cmake
+RUN mkdir src && \
+    cd src && \
+    wget https://cmake.org/files/v3.8/cmake-3.8.0.tar.gz  && \
+    tar zxf cmake-3.8.0.tar.gz && \
+    cd cmake-3.8.0 && \
+    ./configure --prefix=/usr --no-server --no-qt-gui && \
+    make && \
+    make install && \
+    cd ../../ && \
+    rm -rf src
+
+USER nistmni
+ENV HOME /home/nistmni
+WORKDIR /home/nistmni


### PR DESCRIPTION
Hello,

This PR adds a CentOS 6.9 build image. The purpose of this PR is to be able to build minc-toolkit-v2 with a relatively old glibc (version 2.12 circa 2010), so that the binaries are compatible with most newer distributions. I intend to use these binaries for kaczmarj/neurodocker#79.

The build fails on `dcm2mnc` (error: undefined reference to \`jpeg_mem_src'), unless libjpegturbo.so is explicitly linked in the links.txt file for `dcm2mnc`. There might be a better way around this issue that I do not know about. I compiled minc-toolkit-v2 (v1.9.15) on this docker image and uploaded the binaries to dropbox: https://www.dropbox.com/s/i1tmdxx4gbrqr3r/minc-toolkit-1.9.15-20170529-CentOS_6.9-x86_64.tar.gz?dl=0. I haven't tested the build. Is the test-suite still broken?

Thank you,
Jakub