### PR TITLE
fix: install libjpeg-turbo through yum

### DIFF
--- a/build_centos_6.9_x64/Dockerfile
+++ b/build_centos_6.9_x64/Dockerfile
@@ -7,20 +7,24 @@ RUN \
     yum -y groupinstall 'Development Tools'  && \
     yum -y install sudo libX11-devel libXmu-devel libXi-devel \
                    mesa-libGL-devel mesa-libGLU-devel \
-                   libjpeg-turbo-devel openjpeg-devel \
                    openssl-devel rpm-build-libs rpm-devel && \
     yum -y clean all && \
     rm -rf /var/cache/yum/* /tmp/* /var/tmp/*
 
 # Install newer gcc, binutils, gfortran, libjpegturbo
-RUN wget http://people.centos.org/tru/devtools-2/devtools-2.repo -O /etc/yum.repos.d/devtools-2.repo && \
-    yum install -y -q devtoolset-2-gcc-c++ devtoolset-2-binutils devtoolset-2-gcc-gfortran && \
+# `rpm --import` related to centos 6 bug 0008226
+RUN wget -O /etc/yum.repos.d/devtools-2.repo http://people.centos.org/tru/devtools-2/devtools-2.repo && \
+    wget -O /etc/yum.repos.d/libjpeg-turbo.repo https://libjpeg-turbo.org/pmwiki/uploads/Downloads/libjpeg-turbo.repo && \
+    rpm --import "http://pgp.mit.edu/pks/lookup?op=get&search=0x85C7044E033FDE16" && \
+    rm -rf /usr/lib64/libjpeg* && \
+    yum install -y -q devtoolset-2-gcc-c++ \
+                      devtoolset-2-binutils \
+                      devtoolset-2-gcc-gfortran \
+                      libjpeg-turbo-official-1.3.1-20140321.x86_64 && \
     yum -y clean all && \
     rm -rf /var/cache/yum/* /tmp/* /var/tmp/* && \
-    rpm -i https://sourceforge.net/projects/libjpeg-turbo/files/1.3.1/libjpeg-turbo-official-1.3.1.x86_64.rpm/download && \
-    echo "/opt/libjpeg-turbo/lib64" >> /etc/ld.so.conf && \
-    rm /etc/ld.so.cache && \
-    ldconfig
+    ln -sfv /opt/libjpeg-turbo/lib64/lib*.so* /usr/lib64 && \
+    ln -sfv /opt/libjpeg-turbo/include/*.h /usr/include
 ENV PATH=/opt/rh/devtoolset-2/root/usr/bin:$PATH
 
 # add user to build all tools


### PR DESCRIPTION
This fixes the issue where `libjpegturbo` had to be linked manually for `dcm2mnc`.
`build_v2.sh` can be run without manual interference. This also removes `libopenjpeg` (it is not available in the debian:stretch apt repositories).

I rebuilt minc-toolkit-v2 on this updated Docker image and uploaded the binaries to dropbox: https://www.dropbox.com/s/40hjzizaqi91373/minc-toolkit-1.9.15-20170529-CentOS_6.9-x86_64.tar.gz?dl=0

related to kaczmarj/neurodocker#79