### PR TITLE
Fix 32bit docker instances to report the proper arch for packaging

### DIFF
--- a/build_centos_6_x32/Dockerfile
+++ b/build_centos_6_x32/Dockerfile
@@ -65,3 +65,5 @@ RUN mkdir src && \
 USER nistmni
 ENV HOME /home/nistmni
 WORKDIR /home/nistmni
+
+ENTRYPOINT ["/usr/bin/linux32", "--"]

--- a/build_ubuntu_14.04_x32/Dockerfile
+++ b/build_ubuntu_14.04_x32/Dockerfile
@@ -38,3 +38,4 @@ RUN mkdir src && \
 USER nistmni
 ENV HOME /home/nistmni
 WORKDIR /home/nistmni
+ENTRYPOINT ["/usr/bin/linux32", "--"]

--- a/build_ubuntu_16.04_x32/Dockerfile
+++ b/build_ubuntu_16.04_x32/Dockerfile
@@ -39,3 +39,4 @@ RUN mkdir src && \
 USER nistmni
 ENV HOME /home/nistmni
 WORKDIR /home/nistmni
+ENTRYPOINT ["/usr/bin/linux32", "--"]


### PR DESCRIPTION
Fix the 32bit instances reporting x86_64 from uname 